### PR TITLE
Separate commands for each individual transform

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -8,13 +8,15 @@ export default class Converter {
 
     convert() {
         const {code, warnings} = lebab.transform(this.getText(), this.getTransforms());
-        if (warnings.length == 0) {
-            this.setText(code);
-        } else {
+
+        // Display warnings when there are some
+        if (warnings.length > 0) {
             this.addWarnings(warnings);
-            if (atom.config.get('atom-lebab.ignoreWarnings')) {
-                this.setText(code);
-            }
+        }
+
+        // Apply changes when there are no warnings or we're ignoring them
+        if (warnings.length === 0 || atom.config.get('atom-lebab.ignoreWarnings')) {
+            this.setText(code);
         }
     }
 

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -11,7 +11,7 @@ export default class Converter {
 
         // Display warnings when there are some
         if (warnings.length > 0) {
-            this.addWarnings(warnings);
+            this.showWarnings(warnings);
         }
 
         // Apply changes when there are no warnings or we're ignoring them
@@ -42,7 +42,7 @@ export default class Converter {
         }
     }
 
-    addWarnings(warnings) {
+    showWarnings(warnings) {
         atom.notifications.addWarning('Lebab transform warning', {
             dismissable: true,
             detail: warnings.map(w => this.formatWarning(w)).join("\n"),

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -2,16 +2,19 @@
 import lebab from 'lebab';
 
 export default class Converter {
+    constructor() {
+        this.editor = atom.workspace.getActiveTextEditor();
+    }
+
     convert() {
-        const editor = atom.workspace.getActiveTextEditor();
-        const isSelected = editor.getSelectedText().length > 0;
-        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), this.getTransforms());
+        const isSelected = this.editor.getSelectedText().length > 0;
+        const {code, warnings} = lebab.transform(isSelected ? this.editor.getSelectedText() : this.editor.getText(), this.getTransforms());
         if (warnings.length == 0) {
-            this.setText(code, isSelected, editor);
+            this.setText(code, isSelected);
         } else {
-            this.addWarnings(warnings, isSelected, editor);
+            this.addWarnings(warnings, isSelected);
             if (atom.config.get('atom-lebab.ignoreWarnings')) {
-                this.setText(code, isSelected, editor);
+                this.setText(code, isSelected);
             }
         }
     }
@@ -22,17 +25,17 @@ export default class Converter {
             .map(([name]) => name);
     }
 
-    setText(code, isSelected, editor) {
+    setText(code, isSelected) {
         if (isSelected) {
-            const buffer = editor.getSelectedBufferRange();
-            editor.setTextInBufferRange(buffer, code);
+            const buffer = this.editor.getSelectedBufferRange();
+            this.editor.setTextInBufferRange(buffer, code);
         } else {
-            editor.setText(code);
+            this.editor.setText(code);
         }
     }
 
-    addWarnings(warnings, isSelected, editor) {
-        const startSelectedLineNumber = isSelected && editor.getSelectedBufferRange().start.row;
+    addWarnings(warnings, isSelected) {
+        const startSelectedLineNumber = isSelected && this.editor.getSelectedBufferRange().start.row;
         const lines = warnings.map((warning) => {
             const {line, msg, type} = warning;
             const realLine = isSelected ? startSelectedLineNumber + line : line;

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,0 +1,46 @@
+"use babel";
+import lebab from 'lebab';
+
+export default class Converter {
+    convert() {
+        const editor = atom.workspace.getActiveTextEditor();
+        const isSelected = editor.getSelectedText().length > 0;
+        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), this.getTransforms());
+        if (warnings.length == 0) {
+            this.setText(code, isSelected, editor);
+        } else {
+            this.addWarnings(warnings, isSelected, editor);
+            if (atom.config.get('atom-lebab.ignoreWarnings')) {
+                this.setText(code, isSelected, editor);
+            }
+        }
+    }
+
+    getTransforms() {
+        return Object.entries(atom.config.get('atom-lebab.transforms'))
+            .filter(([name, enabled]) => enabled)
+            .map(([name]) => name);
+    }
+
+    setText(code, isSelected, editor) {
+        if (isSelected) {
+            const buffer = editor.getSelectedBufferRange();
+            editor.setTextInBufferRange(buffer, code);
+        } else {
+            editor.setText(code);
+        }
+    }
+
+    addWarnings(warnings, isSelected, editor) {
+        const startSelectedLineNumber = isSelected && editor.getSelectedBufferRange().start.row;
+        const lines = warnings.map((warning) => {
+            const {line, msg, type} = warning;
+            const realLine = isSelected ? startSelectedLineNumber + line : line;
+            return `[${type}] line ${realLine}: ${msg}`;
+        });
+        atom.notifications.addWarning('Lebab transform warning', {
+            dismissable: true,
+            detail: lines.join("\n"),
+        });
+    }
+}

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -43,14 +43,16 @@ export default class Converter {
     }
 
     addWarnings(warnings) {
-        const startSelectedLineNumber = this.isSelected() ? this.editor.getSelectedBufferRange().start.row : 0;
         const lines = warnings.map(({line, msg, type}) => {
-            const realLine = startSelectedLineNumber + line;
-            return `[${type}] line ${realLine}: ${msg}`;
+            return `[${type}] line ${this.getStartLine() + line}: ${msg}`;
         });
         atom.notifications.addWarning('Lebab transform warning', {
             dismissable: true,
             detail: lines.join("\n"),
         });
+    }
+
+    getStartLine(line) {
+        return this.isSelected() ? this.editor.getSelectedBufferRange().start.row : 0;
     }
 }

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -43,10 +43,9 @@ export default class Converter {
     }
 
     addWarnings(warnings) {
-        const lines = warnings.map(w => this.formatWarning(w));
         atom.notifications.addWarning('Lebab transform warning', {
             dismissable: true,
-            detail: lines.join("\n"),
+            detail: warnings.map(w => this.formatWarning(w)).join("\n"),
         });
     }
 

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -7,7 +7,7 @@ export default class Converter {
     }
 
     convert() {
-        const {code, warnings} = lebab.transform(this.isSelected() ? this.editor.getSelectedText() : this.editor.getText(), this.getTransforms());
+        const {code, warnings} = lebab.transform(this.getText(), this.getTransforms());
         if (warnings.length == 0) {
             this.setText(code);
         } else {
@@ -26,6 +26,10 @@ export default class Converter {
 
     isSelected() {
         return this.editor.getSelectedText().length > 0;
+    }
+
+    getText() {
+        return this.isSelected() ? this.editor.getSelectedText() : this.editor.getText();
     }
 
     setText(code) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -6,8 +6,8 @@ export default class Converter {
         this.editor = atom.workspace.getActiveTextEditor();
     }
 
-    convert() {
-        const {code, warnings} = lebab.transform(this.getText(), this.getTransforms());
+    convert(transforms) {
+        const {code, warnings} = lebab.transform(this.getText(), transforms);
 
         // Display warnings when there are some
         if (warnings.length > 0) {
@@ -18,12 +18,6 @@ export default class Converter {
         if (warnings.length === 0 || atom.config.get('atom-lebab.ignoreWarnings')) {
             this.setText(code);
         }
-    }
-
-    getTransforms() {
-        return Object.entries(atom.config.get('atom-lebab.transforms'))
-            .filter(([name, enabled]) => enabled)
-            .map(([name]) => name);
     }
 
     isSelected() {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -7,14 +7,13 @@ export default class Converter {
     }
 
     convert() {
-        const isSelected = this.editor.getSelectedText().length > 0;
-        const {code, warnings} = lebab.transform(isSelected ? this.editor.getSelectedText() : this.editor.getText(), this.getTransforms());
+        const {code, warnings} = lebab.transform(this.isSelected() ? this.editor.getSelectedText() : this.editor.getText(), this.getTransforms());
         if (warnings.length == 0) {
-            this.setText(code, isSelected);
+            this.setText(code);
         } else {
-            this.addWarnings(warnings, isSelected);
+            this.addWarnings(warnings);
             if (atom.config.get('atom-lebab.ignoreWarnings')) {
-                this.setText(code, isSelected);
+                this.setText(code);
             }
         }
     }
@@ -25,8 +24,12 @@ export default class Converter {
             .map(([name]) => name);
     }
 
-    setText(code, isSelected) {
-        if (isSelected) {
+    isSelected() {
+        return this.editor.getSelectedText().length > 0;
+    }
+
+    setText(code) {
+        if (this.isSelected()) {
             const buffer = this.editor.getSelectedBufferRange();
             this.editor.setTextInBufferRange(buffer, code);
         } else {
@@ -34,11 +37,11 @@ export default class Converter {
         }
     }
 
-    addWarnings(warnings, isSelected) {
-        const startSelectedLineNumber = isSelected && this.editor.getSelectedBufferRange().start.row;
+    addWarnings(warnings) {
+        const startSelectedLineNumber = this.isSelected() && this.editor.getSelectedBufferRange().start.row;
         const lines = warnings.map((warning) => {
             const {line, msg, type} = warning;
-            const realLine = isSelected ? startSelectedLineNumber + line : line;
+            const realLine = this.isSelected() ? startSelectedLineNumber + line : line;
             return `[${type}] line ${realLine}: ${msg}`;
         });
         atom.notifications.addWarning('Lebab transform warning', {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -43,9 +43,9 @@ export default class Converter {
     }
 
     addWarnings(warnings) {
-        const startSelectedLineNumber = this.isSelected() && this.editor.getSelectedBufferRange().start.row;
+        const startSelectedLineNumber = this.isSelected() ? this.editor.getSelectedBufferRange().start.row : 0;
         const lines = warnings.map(({line, msg, type}) => {
-            const realLine = this.isSelected() ? startSelectedLineNumber + line : line;
+            const realLine = startSelectedLineNumber + line;
             return `[${type}] line ${realLine}: ${msg}`;
         });
         atom.notifications.addWarning('Lebab transform warning', {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -43,13 +43,15 @@ export default class Converter {
     }
 
     addWarnings(warnings) {
-        const lines = warnings.map(({line, msg, type}) => {
-            return `[${type}] line ${this.getStartLine() + line}: ${msg}`;
-        });
+        const lines = warnings.map(w => this.formatWarning(w));
         atom.notifications.addWarning('Lebab transform warning', {
             dismissable: true,
             detail: lines.join("\n"),
         });
+    }
+
+    formatWarning({line, msg, type}) {
+        return `[${type}] line ${this.getStartLine() + line}: ${msg}`;
     }
 
     getStartLine(line) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -44,8 +44,7 @@ export default class Converter {
 
     addWarnings(warnings) {
         const startSelectedLineNumber = this.isSelected() && this.editor.getSelectedBufferRange().start.row;
-        const lines = warnings.map((warning) => {
-            const {line, msg, type} = warning;
+        const lines = warnings.map(({line, msg, type}) => {
             const realLine = this.isSelected() ? startSelectedLineNumber + line : line;
             return `[${type}] line ${realLine}: ${msg}`;
         });

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -36,8 +36,7 @@ export default class Converter {
 
     setText(code) {
         if (this.isSelected()) {
-            const buffer = this.editor.getSelectedBufferRange();
-            this.editor.setTextInBufferRange(buffer, code);
+            this.editor.setTextInBufferRange(this.editor.getSelectedBufferRange(), code);
         } else {
             this.editor.setText(code);
         }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -10,15 +10,8 @@ export function activate() {
 function convert(event) {
     try {
         const editor = atom.workspace.getActiveTextEditor();
-        const transforms = [];
-        const transformsConfig = atom.config.get('atom-lebab.transforms');
-        Object.keys(transformsConfig).forEach((item) => {
-            if (transformsConfig[item]) {
-                transforms.push(item);
-            }
-        });
         const isSelected = editor.getSelectedText().length > 0;
-        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), transforms);
+        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), getTransforms());
         if (warnings.length == 0) {
             setText(code, isSelected, editor);
         } else {
@@ -28,6 +21,17 @@ function convert(event) {
             }
         }
     } catch (error) {}
+}
+
+function getTransforms() {
+    const transforms = [];
+    const transformsConfig = atom.config.get('atom-lebab.transforms');
+    Object.keys(transformsConfig).forEach((item) => {
+        if (transformsConfig[item]) {
+            transforms.push(item);
+        }
+    });
+    return transforms;
 }
 
 function setText(code, isSelected, editor) {

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -8,5 +8,11 @@ export function activate() {
 }
 
 function convert() {
-    new Converter().convert();
+    new Converter().convert(getEnabledTransforms());
+}
+
+function getEnabledTransforms() {
+    return Object.entries(atom.config.get('atom-lebab.transforms'))
+        .filter(([name, enabled]) => enabled)
+        .map(([name]) => name);
 }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -39,15 +39,14 @@ function setText(code, isSelected, editor) {
 }
 
 function addWarnings(warnings, isSelected, editor) {
-    let detail = "";
     const startSelectedLineNumber = isSelected && editor.getSelectedBufferRange().start.row;
-    warnings.forEach((warning, index) => {
+    const lines = warnings.map((warning) => {
         const {line, msg, type} = warning;
         const realLine = isSelected ? startSelectedLineNumber + line : line;
-        detail += `${index != 0 ? '\n' : ''} [${type}] line ${realLine}: ${msg}`;
+        return `[${type}] line ${realLine}: ${msg}`;
     });
     atom.notifications.addWarning('Lebab transform warning', {
         dismissable: true,
-        detail
+        detail: lines.join("\n"),
     });
 }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -1,5 +1,5 @@
 "use babel";
-import lebab from 'lebab';
+import Converter from './Converter';
 
 export {default as config} from './config';
 
@@ -9,44 +9,6 @@ export function activate() {
 
 function convert() {
     try {
-        const editor = atom.workspace.getActiveTextEditor();
-        const isSelected = editor.getSelectedText().length > 0;
-        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), getTransforms());
-        if (warnings.length == 0) {
-            setText(code, isSelected, editor);
-        } else {
-            addWarnings(warnings, isSelected, editor);
-            if (atom.config.get('atom-lebab.ignoreWarnings')) {
-                setText(code, isSelected, editor);
-            }
-        }
+        new Converter().convert();
     } catch (error) {}
-}
-
-function getTransforms() {
-    return Object.entries(atom.config.get('atom-lebab.transforms'))
-        .filter(([name, enabled]) => enabled)
-        .map(([name]) => name);
-}
-
-function setText(code, isSelected, editor) {
-    if (isSelected) {
-        const buffer = editor.getSelectedBufferRange();
-        editor.setTextInBufferRange(buffer, code);
-    } else {
-        editor.setText(code);
-    }
-}
-
-function addWarnings(warnings, isSelected, editor) {
-    const startSelectedLineNumber = isSelected && editor.getSelectedBufferRange().start.row;
-    const lines = warnings.map((warning) => {
-        const {line, msg, type} = warning;
-        const realLine = isSelected ? startSelectedLineNumber + line : line;
-        return `[${type}] line ${realLine}: ${msg}`;
-    });
-    atom.notifications.addWarning('Lebab transform warning', {
-        dismissable: true,
-        detail: lines.join("\n"),
-    });
 }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -7,7 +7,7 @@ export function activate() {
     atom.commands.add("atom-workspace", "atom-lebab:convert", convert);
 }
 
-function convert(event) {
+function convert() {
     try {
         const editor = atom.workspace.getActiveTextEditor();
         const isSelected = editor.getSelectedText().length > 0;

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -4,15 +4,37 @@ import Converter from './Converter';
 export {default as config} from './config';
 
 export function activate() {
-    atom.commands.add("atom-workspace", "atom-lebab:convert", convert);
+    // Command for applying all enabled transforms
+    atom.commands.add(
+        "atom-workspace",
+        "atom-lebab:convert",
+        () => convert(getEnabledTransforms())
+    );
+
+    // Commands for applying each transform separately
+    getAllTransforms().forEach(transform => {
+        atom.commands.add(
+            "atom-workspace",
+            `atom-lebab:convert-${transform}`,
+            () => convert([transform])
+        );
+    });
 }
 
-function convert() {
-    new Converter().convert(getEnabledTransforms());
+function convert(transforms) {
+    new Converter().convert(transforms);
 }
 
 function getEnabledTransforms() {
-    return Object.entries(atom.config.get('atom-lebab.transforms'))
+    return getTransformConfigs()
         .filter(([name, enabled]) => enabled)
         .map(([name]) => name);
+}
+
+function getAllTransforms() {
+    return getTransformConfigs().map(([name]) => name);
+}
+
+function getTransformConfigs() {
+    return Object.entries(atom.config.get('atom-lebab.transforms'));
 }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -18,7 +18,7 @@ function convert(event) {
             }
         });
         const isSelected = editor.getSelectedText().length > 0;
-        const {code, warnings} = lebab.transform(isSelected && editor.getSelectedText() || editor.getText(), transforms);
+        const {code, warnings} = lebab.transform(isSelected ? editor.getSelectedText() : editor.getText(), transforms);
         if (warnings.length == 0) {
             setText(code, isSelected, editor);
         } else {
@@ -44,8 +44,8 @@ function addWarnings(warnings, isSelected, editor) {
     const startSelectedLineNumber = isSelected && editor.getSelectedBufferRange().start.row;
     warnings.forEach((warning, index) => {
         const {line, msg, type} = warning;
-        const realLine = isSelected && startSelectedLineNumber + line || line;
-        detail += `${index != 0 && '\n' || ''} [${type}] line ${realLine}: ${msg}`;
+        const realLine = isSelected ? startSelectedLineNumber + line : line;
+        detail += `${index != 0 ? '\n' : ''} [${type}] line ${realLine}: ${msg}`;
     });
     atom.notifications.addWarning('Lebab transform warning', {
         dismissable: true,

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -24,14 +24,9 @@ function convert(event) {
 }
 
 function getTransforms() {
-    const transforms = [];
-    const transformsConfig = atom.config.get('atom-lebab.transforms');
-    Object.keys(transformsConfig).forEach((item) => {
-        if (transformsConfig[item]) {
-            transforms.push(item);
-        }
-    });
-    return transforms;
+    return Object.entries(atom.config.get('atom-lebab.transforms'))
+        .filter(([name, enabled]) => enabled)
+        .map(([name]) => name);
 }
 
 function setText(code, isSelected, editor) {

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -8,7 +8,5 @@ export function activate() {
 }
 
 function convert() {
-    try {
-        new Converter().convert();
-    } catch (error) {}
+    new Converter().convert();
 }

--- a/lib/atom-lebab.js
+++ b/lib/atom-lebab.js
@@ -7,7 +7,7 @@ export function activate() {
     atom.commands.add("atom-workspace", "atom-lebab:convert", convert);
 }
 
-export function convert(event) {
+function convert(event) {
     try {
         const editor = atom.workspace.getActiveTextEditor();
         const transforms = [];

--- a/menus/atom-lebab.json
+++ b/menus/atom-lebab.json
@@ -15,8 +15,52 @@
           "label": "Lebab",
           "submenu": [
             {
-              "label": "Convert ES5 to ES6",
+              "label": "Convert all",
               "command": "atom-lebab:convert"
+            },
+            {
+              "label": "Arrow function",
+              "command": "atom-lebab:convert-arrow"
+            },
+            {
+              "label": "Let/Const",
+              "command": "atom-lebab:convert-let"
+            },
+            {
+              "label": "Arguments spread operator",
+              "command": "atom-lebab:convert-arg-spread"
+            },
+            {
+              "label": "Object method",
+              "command": "atom-lebab:convert-obj-method"
+            },
+            {
+              "label": "Object shorthand",
+              "command": "atom-lebab:convert-obj-shorthand"
+            },
+            {
+              "label": "Remove \"no strict\"",
+              "command": "atom-lebab:convert-no-strict"
+            },
+            {
+              "label": "CommonJS to import/export",
+              "command": "atom-lebab:convert-commonjs"
+            },
+            {
+              "label": "Class",
+              "command": "atom-lebab:convert-class"
+            },
+            {
+              "label": "Template string",
+              "command": "atom-lebab:convert-template"
+            },
+            {
+              "label": "Default parameters",
+              "command": "atom-lebab:convert-default-param"
+            },
+            {
+              "label": "Exponentiation operator (ES7)",
+              "command": "atom-lebab:convert-exponent"
             }
           ]
         }

--- a/menus/atom-lebab.json
+++ b/menus/atom-lebab.json
@@ -2,8 +2,57 @@
   "context-menu": {
     "atom-text-editor": [
       {
-        "label": "Convert ES5 to ES6",
-        "command": "atom-lebab:convert"
+        "label": "Lebab",
+        "submenu": [
+          {
+            "label": "Convert all",
+            "command": "atom-lebab:convert"
+          },
+          {
+            "label": "Arrow function",
+            "command": "atom-lebab:convert-arrow"
+          },
+          {
+            "label": "Let/Const",
+            "command": "atom-lebab:convert-let"
+          },
+          {
+            "label": "Arguments spread operator",
+            "command": "atom-lebab:convert-arg-spread"
+          },
+          {
+            "label": "Object method",
+            "command": "atom-lebab:convert-obj-method"
+          },
+          {
+            "label": "Object shorthand",
+            "command": "atom-lebab:convert-obj-shorthand"
+          },
+          {
+            "label": "Remove \"no strict\"",
+            "command": "atom-lebab:convert-no-strict"
+          },
+          {
+            "label": "CommonJS to import/export",
+            "command": "atom-lebab:convert-commonjs"
+          },
+          {
+            "label": "Class",
+            "command": "atom-lebab:convert-class"
+          },
+          {
+            "label": "Template string",
+            "command": "atom-lebab:convert-template"
+          },
+          {
+            "label": "Default parameters",
+            "command": "atom-lebab:convert-default-param"
+          },
+          {
+            "label": "Exponentiation operator (ES7)",
+            "command": "atom-lebab:convert-exponent"
+          }
+        ]
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,20 @@
     "javascript"
   ],
   "activationCommands": {
-    "atom-workspace": "atom-lebab:convert"
+    "atom-workspace": [
+        "atom-lebab:convert",
+        "atom-lebab:convert-arrow",
+        "atom-lebab:convert-let",
+        "atom-lebab:convert-arg-spread",
+        "atom-lebab:convert-obj-method",
+        "atom-lebab:convert-obj-shorthand",
+        "atom-lebab:convert-no-strict",
+        "atom-lebab:convert-commonjs",
+        "atom-lebab:convert-class",
+        "atom-lebab:convert-template",
+        "atom-lebab:convert-default-param",
+        "atom-lebab:convert-exponent"
+    ]
   },
   "repository": "https://github.com/ga2mer/atom-lebab",
   "license": "MIT",


### PR DESCRIPTION
Built on top of the refactoring in #5.

Would be nice to generate all these menus and command lists programmatically, but I don't know whether Atom supports such a thing.
