### PR TITLE
Render warnings in bottom panel instead of popup

### DIFF
--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -3,6 +3,8 @@ import lebab from 'lebab';
 import {Point} from 'atom';
 import WarningsPanel from './WarningsPanel';
 
+const warningsPanel = new WarningsPanel();
+
 export default class Converter {
     constructor() {
         this.editor = atom.workspace.getActiveTextEditor();
@@ -36,7 +38,7 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        new WarningsPanel().show(warnings.map(this.offsetLine, this), (line) => {
+        warningsPanel.show(warnings.map(this.offsetLine, this), (line) => {
             this.editor.setCursorBufferPosition(new Point(line - 1, 0));
         });
     }

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -3,11 +3,10 @@ import lebab from 'lebab';
 import {Point} from 'atom';
 import WarningsPanel from './WarningsPanel';
 
-const warningsPanel = new WarningsPanel();
-
 export default class Converter {
     constructor() {
         this.editor = atom.workspace.getActiveTextEditor();
+        this.warningsPanel = new WarningsPanel();
     }
 
     convert(transforms) {
@@ -38,7 +37,7 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        warningsPanel.show(warnings.map(this.offsetLine, this), (line) => {
+        this.warningsPanel.show(warnings.map(this.offsetLine, this), (line) => {
             this.editor.setCursorBufferPosition(new Point(line - 1, 0));
         });
     }

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,5 +1,6 @@
 "use babel";
 import lebab from 'lebab';
+import {Point} from 'atom';
 import WarningsPanel from './WarningsPanel';
 
 export default class Converter {
@@ -35,9 +36,9 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        new WarningsPanel(this.editor).show(
-            warnings.map(this.offsetLine, this)
-        );
+        new WarningsPanel().show(warnings.map(this.offsetLine, this), (line) => {
+            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
+        });
     }
 
     offsetLine({line, msg, type}) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -4,8 +4,8 @@ import WarningsPanel from './WarningsPanel';
 import EditorFacade from './EditorFacade';
 
 export default class Converter {
-    constructor() {
-        this.editor = new EditorFacade(atom.workspace.getActiveTextEditor());
+    constructor(editor) {
+        this.editor = new EditorFacade(editor);
         this.warningsPanel = new WarningsPanel();
     }
 

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,5 +1,6 @@
 "use babel";
 import lebab from 'lebab';
+import {Point} from 'atom';
 
 export default class Converter {
     constructor() {
@@ -9,10 +10,7 @@ export default class Converter {
     convert(transforms) {
         const {code, warnings} = lebab.transform(this.getText(), transforms);
 
-        // Display warnings when there are some
-        if (warnings.length > 0) {
-            this.showWarnings(warnings);
-        }
+        this.showWarnings(warnings);
 
         // Apply changes when there are no warnings or we're ignoring them
         if (warnings.length === 0 || atom.config.get('lebab.ignoreWarnings')) {
@@ -37,14 +35,75 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        atom.notifications.addWarning('Lebab transform warning', {
-            dismissable: true,
-            detail: warnings.map(w => this.formatWarning(w)).join("\n"),
+        // Close warnings panel, if open from previous time
+        if (Converter.warningsPanel) {
+            this.hideWarnings();
+        }
+
+        if (warnings.length === 0) {
+            return;
+        }
+
+        // Store the panel in static property,
+        // so it will live through different Converter instances
+        Converter.warningsPanel = atom.workspace.addBottomPanel({
+            item: this.createWarningsContainer(warnings)
         });
     }
 
-    formatWarning({line, msg, type}) {
-        return `[${type}] line ${this.getStartLine() + line}: ${msg}`;
+    hideWarnings() {
+        Converter.warningsPanel.destroy();
+        Converter.warningsPanel = undefined;
+    }
+
+    createWarningsContainer(warnings) {
+        return this.createElement("div", "lebab-warnings-container",
+            [this.createCloseButton()].concat(
+                warnings.map(this.offsetLine, this).map(this.createWarning, this)
+            )
+        );
+    }
+
+    createCloseButton() {
+        const link = this.createElement("a", "icon icon-x lebab-warnings-close");
+        link.onclick = () => {
+            this.hideWarnings();
+        };
+        return link;
+    }
+
+    createWarning({line, msg, type}) {
+        return this.createElement("p", "lebab-warning", [
+            this.createElement("span", "inline-block highlight", "Lebab"),
+            this.createElement("span", "inline-block highlight-warning", "Warning"),
+            this.createElement("span", "inline-block highlight", type),
+            this.createElement("span", "lebab-warning__msg", msg),
+            this.createLineNrLink(line),
+        ]);
+    }
+
+    createLineNrLink(line) {
+        const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
+        link.onclick = () => {
+            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
+        };
+        return link;
+    }
+
+    createElement(nodeType, className, children) {
+        const el = document.createElement(nodeType);
+        el.className = className;
+        if (typeof children === "string") {
+            el.appendChild(document.createTextNode(children))
+        }
+        else if (Array.isArray(children)) {
+            children.forEach(child => el.appendChild(child));
+        }
+        return el;
+    }
+
+    offsetLine({line, msg, type}) {
+        return {line: this.getStartLine() + line, msg, type};
     }
 
     getStartLine(line) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -21,9 +21,13 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        this.warningsPanel.show(warnings.map(this.offsetLine, this), (line) => {
+        this.warningsPanel.render(warnings.map(this.offsetLine, this), (line) => {
             this.editor.setCursorLinePosition(line - 1);
         });
+    }
+
+    getWarningsPanel() {
+        return this.warningsPanel;
     }
 
     offsetLine({line, msg, type}) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,6 +1,6 @@
 "use babel";
 import lebab from 'lebab';
-import {Point} from 'atom';
+import WarningsPanel from './WarningsPanel';
 
 export default class Converter {
     constructor() {
@@ -35,71 +35,9 @@ export default class Converter {
     }
 
     showWarnings(warnings) {
-        // Close warnings panel, if open from previous time
-        if (Converter.warningsPanel) {
-            this.hideWarnings();
-        }
-
-        if (warnings.length === 0) {
-            return;
-        }
-
-        // Store the panel in static property,
-        // so it will live through different Converter instances
-        Converter.warningsPanel = atom.workspace.addBottomPanel({
-            item: this.createWarningsContainer(warnings)
-        });
-    }
-
-    hideWarnings() {
-        Converter.warningsPanel.destroy();
-        Converter.warningsPanel = undefined;
-    }
-
-    createWarningsContainer(warnings) {
-        return this.createElement("div", "lebab-warnings-container",
-            [this.createCloseButton()].concat(
-                warnings.map(this.offsetLine, this).map(this.createWarning, this)
-            )
+        new WarningsPanel(this.editor).show(
+            warnings.map(this.offsetLine, this)
         );
-    }
-
-    createCloseButton() {
-        const link = this.createElement("a", "icon icon-x lebab-warnings-close");
-        link.onclick = () => {
-            this.hideWarnings();
-        };
-        return link;
-    }
-
-    createWarning({line, msg, type}) {
-        return this.createElement("p", "lebab-warning", [
-            this.createElement("span", "inline-block highlight", "Lebab"),
-            this.createElement("span", "inline-block highlight-warning", "Warning"),
-            this.createElement("span", "inline-block highlight", type),
-            this.createElement("span", "lebab-warning__msg", msg),
-            this.createLineNrLink(line),
-        ]);
-    }
-
-    createLineNrLink(line) {
-        const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
-        link.onclick = () => {
-            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
-        };
-        return link;
-    }
-
-    createElement(nodeType, className, children) {
-        const el = document.createElement(nodeType);
-        el.className = className;
-        if (typeof children === "string") {
-            el.appendChild(document.createTextNode(children))
-        }
-        else if (Array.isArray(children)) {
-            children.forEach(child => el.appendChild(child));
-        }
-        return el;
     }
 
     offsetLine({line, msg, type}) {

--- a/lib/Converter.js
+++ b/lib/Converter.js
@@ -1,52 +1,32 @@
 "use babel";
 import lebab from 'lebab';
-import {Point} from 'atom';
 import WarningsPanel from './WarningsPanel';
+import EditorFacade from './EditorFacade';
 
 export default class Converter {
     constructor() {
-        this.editor = atom.workspace.getActiveTextEditor();
+        this.editor = new EditorFacade(atom.workspace.getActiveTextEditor());
         this.warningsPanel = new WarningsPanel();
     }
 
     convert(transforms) {
-        const {code, warnings} = lebab.transform(this.getText(), transforms);
+        const {code, warnings} = lebab.transform(this.editor.getText(), transforms);
 
         this.showWarnings(warnings);
 
         // Apply changes when there are no warnings or we're ignoring them
         if (warnings.length === 0 || atom.config.get('lebab.ignoreWarnings')) {
-            this.setText(code);
-        }
-    }
-
-    isSelected() {
-        return this.editor.getSelectedText().length > 0;
-    }
-
-    getText() {
-        return this.isSelected() ? this.editor.getSelectedText() : this.editor.getText();
-    }
-
-    setText(code) {
-        if (this.isSelected()) {
-            this.editor.setTextInBufferRange(this.editor.getSelectedBufferRange(), code);
-        } else {
             this.editor.setText(code);
         }
     }
 
     showWarnings(warnings) {
         this.warningsPanel.show(warnings.map(this.offsetLine, this), (line) => {
-            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
+            this.editor.setCursorLinePosition(line - 1);
         });
     }
 
     offsetLine({line, msg, type}) {
-        return {line: this.getStartLine() + line, msg, type};
-    }
-
-    getStartLine(line) {
-        return this.isSelected() ? this.editor.getSelectedBufferRange().start.row : 0;
+        return {line: this.editor.getStartLine() + line, msg, type};
     }
 }

--- a/lib/ConverterPool.js
+++ b/lib/ConverterPool.js
@@ -1,0 +1,44 @@
+"use babel";
+import Converter from './Converter';
+
+export default class ConverterPool {
+    constructor() {
+        // Use WeakMap to ensure we Converters get garbage-collected
+        // when the associated editor is removed.
+        this.map = new WeakMap();
+    }
+
+    /**
+     * Returns Converter instance for active editor.
+     * @return {Converter}
+     */
+    getActive() {
+        const editor = atom.workspace.getActiveTextEditor();
+        if (!this.map.get(editor)) {
+            this.map.set(editor, this.createConverter(editor));
+        }
+        return this.map.get(editor);
+    }
+
+    createConverter(editor) {
+        const converter = new Converter(editor);
+
+        // Show/Hide warnings panel when active editor changes
+        const listener = atom.workspace.onDidStopChangingActivePaneItem(() => {
+            if (atom.workspace.getActiveTextEditor() === editor) {
+               converter.getWarningsPanel().show();
+            }
+            else {
+               converter.getWarningsPanel().hide();
+            }
+        });
+
+        // When editor is closed, eliminate warnings panel
+        editor.onDidDestroy(() => {
+            converter.getWarningsPanel().destroy();
+            listener.dispose();
+        });
+
+        return converter;
+    }
+}

--- a/lib/EditorFacade.js
+++ b/lib/EditorFacade.js
@@ -1,0 +1,51 @@
+"use babel";
+import {Point} from 'atom';
+
+/**
+ * Simpler API for interacting with the editor.
+ */
+export default class EditorFacade {
+    constructor(editor) {
+        this.editor = editor;
+    }
+
+    isSelected() {
+        return this.editor.getSelectedText().length > 0;
+    }
+
+    /**
+     * Returns the full buffer or just the selected portion.
+     * @return {String}
+     */
+    getText() {
+        return this.isSelected() ? this.editor.getSelectedText() : this.editor.getText();
+    }
+
+    /**
+     * Sets the full buffer or just the selected portion.
+     * @param {String} text
+     */
+    setText(text) {
+        if (this.isSelected()) {
+            this.editor.setTextInBufferRange(this.editor.getSelectedBufferRange(), text);
+        } else {
+            this.editor.setText(text);
+        }
+    }
+
+    /**
+     * Returns the first line of selection or 0 when no selection exists
+     * @return {Number}
+     */
+    getStartLine() {
+        return this.isSelected() ? this.editor.getSelectedBufferRange().start.row : 0;
+    }
+
+    /**
+     * Positions the cursor at given line
+     * @param {Number} line
+     */
+    setCursorLinePosition(line) {
+        this.editor.setCursorBufferPosition(new Point(line, 0));
+    }
+}

--- a/lib/WarningsFormatter.js
+++ b/lib/WarningsFormatter.js
@@ -1,0 +1,55 @@
+"use babel";
+
+export default class {
+    /**
+     * Renders warnings in HTML
+     * @param  {Object[]} warnings
+     * @param  {Object} events Event handlers:
+     * @param  {Function} events.onClick Called with line number when warning clicked on.
+     * @param  {Function} events.onClose Called when close button is clicked.
+     * @return {HTMLElement}
+     */
+    format(warnings, events) {
+        this.events = events;
+
+        return this.createElement("div", "lebab-warnings-container",
+            [this.createCloseButton()].concat(
+                warnings.map(this.createWarning, this)
+            )
+        );
+    }
+
+    createCloseButton() {
+        const link = this.createElement("a", "icon icon-x lebab-warnings-close");
+        link.onclick = this.events.onClose;
+        return link;
+    }
+
+    createWarning({line, msg, type}) {
+        return this.createElement("p", "lebab-warning", [
+            this.createElement("span", "inline-block highlight", "Lebab"),
+            this.createElement("span", "inline-block highlight-warning", "Warning"),
+            this.createElement("span", "inline-block highlight", type),
+            this.createElement("span", "lebab-warning__msg", msg),
+            this.createLineNrLink(line),
+        ]);
+    }
+
+    createLineNrLink(line) {
+        const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
+        link.onclick = () => this.events.onClick(line);
+        return link;
+    }
+
+    createElement(nodeType, className, children) {
+        const el = document.createElement(nodeType);
+        el.className = className;
+        if (typeof children === "string") {
+            el.appendChild(document.createTextNode(children))
+        }
+        else if (Array.isArray(children)) {
+            children.forEach(child => el.appendChild(child));
+        }
+        return el;
+    }
+}

--- a/lib/WarningsPanel.js
+++ b/lib/WarningsPanel.js
@@ -1,12 +1,14 @@
 "use babel";
-import {Point} from 'atom';
 
 export default class WarningsPanel {
-    constructor(editor) {
-        this.editor = editor;
-    }
+    /**
+     * Shows warnings in bottom panel
+     * @param  {Object[]} warnings
+     * @param  {Function} onclick Called with line number when warning clicked on.
+     */
+    show(warnings, onclick) {
+        this.onclick = onclick;
 
-    show(warnings) {
         // Close warnings panel, if open from previous time
         if (WarningsPanel.panel) {
             this.hide();
@@ -56,9 +58,7 @@ export default class WarningsPanel {
 
     createLineNrLink(line) {
         const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
-        link.onclick = () => {
-            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
-        };
+        link.onclick = () => this.onclick(line);
         return link;
     }
 

--- a/lib/WarningsPanel.js
+++ b/lib/WarningsPanel.js
@@ -9,8 +9,8 @@ export default class WarningsPanel {
     show(warnings, onclick) {
         this.onclick = onclick;
 
-        // Close warnings panel, if open from previous time
-        if (WarningsPanel.panel) {
+        // Close the panel, if open from previous time
+        if (this.panel) {
             this.hide();
         }
 
@@ -18,16 +18,14 @@ export default class WarningsPanel {
             return;
         }
 
-        // Store the panel in static property,
-        // so it will live through different WarningsPanel instances
-        WarningsPanel.panel = atom.workspace.addBottomPanel({
+        this.panel = atom.workspace.addBottomPanel({
             item: this.createWarningsContainer(warnings)
         });
     }
 
     hide() {
-        WarningsPanel.panel.destroy();
-        WarningsPanel.panel = undefined;
+        this.panel.destroy();
+        this.panel = undefined;
     }
 
     createWarningsContainer(warnings) {

--- a/lib/WarningsPanel.js
+++ b/lib/WarningsPanel.js
@@ -7,11 +7,9 @@ export default class WarningsPanel {
      * @param  {Object[]} warnings
      * @param  {Function} onClick Called with line number when warning clicked on.
      */
-    show(warnings, onClick) {
+    render(warnings, onClick) {
         // Close the panel, if open from previous time
-        if (this.panel) {
-            this.hide();
-        }
+        this.destroy();
 
         if (warnings.length === 0) {
             return;
@@ -20,13 +18,36 @@ export default class WarningsPanel {
         this.panel = atom.workspace.addBottomPanel({
             item: new WarningsFormatter().format(warnings, {
                 onClick: onClick,
-                onClose: () => this.hide(),
+                onClose: () => this.destroy(),
             })
         });
     }
 
+    /**
+     * Destroys the warnings panel (if it exists)
+     */
+    destroy() {
+        if (this.panel) {
+            this.panel.destroy();
+            this.panel = undefined;
+        }
+    }
+
+    /**
+     * Shows the warnings panel (if it exists)
+     */
+    show() {
+        if (this.panel) {
+            this.panel.show();
+        }
+    }
+
+    /**
+     * Hides the warnings panel (if it exists)
+     */
     hide() {
-        this.panel.destroy();
-        this.panel = undefined;
+        if (this.panel) {
+            this.panel.hide();
+        }
     }
 }

--- a/lib/WarningsPanel.js
+++ b/lib/WarningsPanel.js
@@ -1,14 +1,13 @@
 "use babel";
+import WarningsFormatter from "./WarningsFormatter";
 
 export default class WarningsPanel {
     /**
      * Shows warnings in bottom panel
      * @param  {Object[]} warnings
-     * @param  {Function} onclick Called with line number when warning clicked on.
+     * @param  {Function} onClick Called with line number when warning clicked on.
      */
-    show(warnings, onclick) {
-        this.onclick = onclick;
-
+    show(warnings, onClick) {
         // Close the panel, if open from previous time
         if (this.panel) {
             this.hide();
@@ -19,56 +18,15 @@ export default class WarningsPanel {
         }
 
         this.panel = atom.workspace.addBottomPanel({
-            item: this.createWarningsContainer(warnings)
+            item: new WarningsFormatter().format(warnings, {
+                onClick: onClick,
+                onClose: () => this.hide(),
+            })
         });
     }
 
     hide() {
         this.panel.destroy();
         this.panel = undefined;
-    }
-
-    createWarningsContainer(warnings) {
-        return this.createElement("div", "lebab-warnings-container",
-            [this.createCloseButton()].concat(
-                warnings.map(this.createWarning, this)
-            )
-        );
-    }
-
-    createCloseButton() {
-        const link = this.createElement("a", "icon icon-x lebab-warnings-close");
-        link.onclick = () => {
-            this.hide();
-        };
-        return link;
-    }
-
-    createWarning({line, msg, type}) {
-        return this.createElement("p", "lebab-warning", [
-            this.createElement("span", "inline-block highlight", "Lebab"),
-            this.createElement("span", "inline-block highlight-warning", "Warning"),
-            this.createElement("span", "inline-block highlight", type),
-            this.createElement("span", "lebab-warning__msg", msg),
-            this.createLineNrLink(line),
-        ]);
-    }
-
-    createLineNrLink(line) {
-        const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
-        link.onclick = () => this.onclick(line);
-        return link;
-    }
-
-    createElement(nodeType, className, children) {
-        const el = document.createElement(nodeType);
-        el.className = className;
-        if (typeof children === "string") {
-            el.appendChild(document.createTextNode(children))
-        }
-        else if (Array.isArray(children)) {
-            children.forEach(child => el.appendChild(child));
-        }
-        return el;
     }
 }

--- a/lib/WarningsPanel.js
+++ b/lib/WarningsPanel.js
@@ -1,0 +1,76 @@
+"use babel";
+import {Point} from 'atom';
+
+export default class WarningsPanel {
+    constructor(editor) {
+        this.editor = editor;
+    }
+
+    show(warnings) {
+        // Close warnings panel, if open from previous time
+        if (WarningsPanel.panel) {
+            this.hide();
+        }
+
+        if (warnings.length === 0) {
+            return;
+        }
+
+        // Store the panel in static property,
+        // so it will live through different WarningsPanel instances
+        WarningsPanel.panel = atom.workspace.addBottomPanel({
+            item: this.createWarningsContainer(warnings)
+        });
+    }
+
+    hide() {
+        WarningsPanel.panel.destroy();
+        WarningsPanel.panel = undefined;
+    }
+
+    createWarningsContainer(warnings) {
+        return this.createElement("div", "lebab-warnings-container",
+            [this.createCloseButton()].concat(
+                warnings.map(this.createWarning, this)
+            )
+        );
+    }
+
+    createCloseButton() {
+        const link = this.createElement("a", "icon icon-x lebab-warnings-close");
+        link.onclick = () => {
+            this.hide();
+        };
+        return link;
+    }
+
+    createWarning({line, msg, type}) {
+        return this.createElement("p", "lebab-warning", [
+            this.createElement("span", "inline-block highlight", "Lebab"),
+            this.createElement("span", "inline-block highlight-warning", "Warning"),
+            this.createElement("span", "inline-block highlight", type),
+            this.createElement("span", "lebab-warning__msg", msg),
+            this.createLineNrLink(line),
+        ]);
+    }
+
+    createLineNrLink(line) {
+        const link = this.createElement("a", "lebab-warning__line", `at line ${line}`)
+        link.onclick = () => {
+            this.editor.setCursorBufferPosition(new Point(line - 1, 0));
+        };
+        return link;
+    }
+
+    createElement(nodeType, className, children) {
+        const el = document.createElement(nodeType);
+        el.className = className;
+        if (typeof children === "string") {
+            el.appendChild(document.createTextNode(children))
+        }
+        else if (Array.isArray(children)) {
+            children.forEach(child => el.appendChild(child));
+        }
+        return el;
+    }
+}

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -7,6 +7,8 @@ export default {
     config,
 
     activate() {
+        this.converter = new Converter();
+
         // Command for applying all enabled transforms
         atom.commands.add(
             "atom-workspace",
@@ -25,6 +27,6 @@ export default {
     },
 
     convert(transforms) {
-        new Converter().convert(transforms);
+        this.converter.convert(transforms);
     },
 }

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -1,5 +1,6 @@
 "use babel";
 import Converter from './Converter';
+import transforms from './transforms';
 
 export {default as config} from './config';
 
@@ -8,11 +9,11 @@ export function activate() {
     atom.commands.add(
         "atom-workspace",
         "lebab:convert",
-        () => convert(getEnabledTransforms())
+        () => convert(transforms.getEnabled())
     );
 
     // Commands for applying each transform separately
-    getAllTransforms().forEach(transform => {
+    transforms.getAll().forEach(transform => {
         atom.commands.add(
             "atom-workspace",
             `lebab:convert-${transform}`,
@@ -23,18 +24,4 @@ export function activate() {
 
 function convert(transforms) {
     new Converter().convert(transforms);
-}
-
-function getEnabledTransforms() {
-    return getTransformConfigs()
-        .filter(([name, enabled]) => enabled)
-        .map(([name]) => name);
-}
-
-function getAllTransforms() {
-    return getTransformConfigs().map(([name]) => name);
-}
-
-function getTransformConfigs() {
-    return Object.entries(atom.config.get('lebab.transforms'));
 }

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -1,27 +1,30 @@
 "use babel";
 import Converter from './Converter';
 import transforms from './transforms';
+import config from './config';
 
-export {default as config} from './config';
+export default {
+    config,
 
-export function activate() {
-    // Command for applying all enabled transforms
-    atom.commands.add(
-        "atom-workspace",
-        "lebab:convert",
-        () => convert(transforms.getEnabled())
-    );
-
-    // Commands for applying each transform separately
-    transforms.getAll().forEach(transform => {
+    activate() {
+        // Command for applying all enabled transforms
         atom.commands.add(
             "atom-workspace",
-            `lebab:convert-${transform}`,
-            () => convert([transform])
+            "lebab:convert",
+            () => this.convert(transforms.getEnabled())
         );
-    });
-}
 
-function convert(transforms) {
-    new Converter().convert(transforms);
+        // Commands for applying each transform separately
+        transforms.getAll().forEach(transform => {
+            atom.commands.add(
+                "atom-workspace",
+                `lebab:convert-${transform}`,
+                () => this.convert([transform])
+            );
+        });
+    },
+
+    convert(transforms) {
+        new Converter().convert(transforms);
+    },
 }

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -1,13 +1,14 @@
 "use babel";
-import Converter from './Converter';
+import ConverterPool from './ConverterPool';
 import transforms from './transforms';
 import config from './config';
 
 export default {
     config,
-    converterMap: new WeakMap(),
 
     activate() {
+        this.converterPool = new ConverterPool();
+
         // Command for applying all enabled transforms
         atom.commands.add(
             "atom-workspace",
@@ -26,36 +27,6 @@ export default {
     },
 
     convert(transforms) {
-        this.getConverter().convert(transforms);
-    },
-
-    getConverter() {
-        const editor = atom.workspace.getActiveTextEditor();
-        if (!this.converterMap.get(editor)) {
-            this.converterMap.set(editor, this.createConverter(editor));
-        }
-        return this.converterMap.get(editor);
-    },
-
-    createConverter(editor) {
-        const converter = new Converter(editor);
-
-        // Show/Hide warnings panel when active editor changes
-        const listener = atom.workspace.onDidStopChangingActivePaneItem(() => {
-            if (atom.workspace.getActiveTextEditor() === editor) {
-               converter.getWarningsPanel().show();
-            }
-            else {
-               converter.getWarningsPanel().hide();
-            }
-        });
-
-        // When editor is closed, eliminate warnings panel
-        editor.onDidDestroy(() => {
-            converter.getWarningsPanel().destroy();
-            listener.dispose();
-        });
-
-        return converter;
+        this.converterPool.getActive().convert(transforms);
     },
 }

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -5,10 +5,9 @@ import config from './config';
 
 export default {
     config,
+    converterMap: new WeakMap(),
 
     activate() {
-        this.converter = new Converter();
-
         // Command for applying all enabled transforms
         atom.commands.add(
             "atom-workspace",
@@ -27,6 +26,14 @@ export default {
     },
 
     convert(transforms) {
-        this.converter.convert(transforms);
+        this.getConverter().convert(transforms);
     },
+
+    getConverter() {
+        const editor = atom.workspace.getActiveTextEditor();
+        if (!this.converterMap.get(editor)) {
+            this.converterMap.set(editor, new Converter(editor));
+        }
+        return this.converterMap.get(editor);
+    }
 }

--- a/lib/lebab.js
+++ b/lib/lebab.js
@@ -32,8 +32,30 @@ export default {
     getConverter() {
         const editor = atom.workspace.getActiveTextEditor();
         if (!this.converterMap.get(editor)) {
-            this.converterMap.set(editor, new Converter(editor));
+            this.converterMap.set(editor, this.createConverter(editor));
         }
         return this.converterMap.get(editor);
-    }
+    },
+
+    createConverter(editor) {
+        const converter = new Converter(editor);
+
+        // Show/Hide warnings panel when active editor changes
+        const listener = atom.workspace.onDidStopChangingActivePaneItem(() => {
+            if (atom.workspace.getActiveTextEditor() === editor) {
+               converter.getWarningsPanel().show();
+            }
+            else {
+               converter.getWarningsPanel().hide();
+            }
+        });
+
+        // When editor is closed, eliminate warnings panel
+        editor.onDidDestroy(() => {
+            converter.getWarningsPanel().destroy();
+            listener.dispose();
+        });
+
+        return converter;
+    },
 }

--- a/lib/transforms.js
+++ b/lib/transforms.js
@@ -1,0 +1,25 @@
+"use babel";
+
+export default {
+    /**
+     * Get list of all transforms enabled in settings.
+     * @return {String[]}
+     */
+    getEnabled() {
+        return this.getConfigs()
+            .filter(([name, enabled]) => enabled)
+            .map(([name]) => name);
+    },
+
+    /**
+     * Get list of all availeble transforms.
+     * @return {String[]}
+     */
+    getAll() {
+        return this.getConfigs().map(([name]) => name);
+    },
+
+    getConfigs() {
+        return Object.entries(atom.config.get('lebab.transforms'));
+    },
+}

--- a/styles/lebab.less
+++ b/styles/lebab.less
@@ -1,0 +1,21 @@
+@import "ui-variables";
+
+.lebab-warnings-close {
+    float: right;
+}
+
+.lebab-warning {
+    font-size: smaller;
+    margin: 0;
+}
+
+.lebab-warning__msg {
+    color: @text-color;
+    font-size: @font-size;
+}
+
+.lebab-warning__line {
+    color: @text-color-highlight;
+    padding-left: 0.8em;
+    font-size: @font-size;
+}


### PR DESCRIPTION
- Style them similarly to ESLint errors using Atom default styles
- Clicking the line number navigates to the line in editor
- Clicking the close button closes the warnings panel

There's one problem: the panel is global, not tied to active editor. So when you switch to another tab you'll still see the warnings panel. Haven't yet found a way to achieve that from Atom API docs.
